### PR TITLE
Substitute import of deprecated module

### DIFF
--- a/beetsplug/xtractor/__init__.py
+++ b/beetsplug/xtractor/__init__.py
@@ -7,7 +7,7 @@
 import os
 
 from beets.plugins import BeetsPlugin
-from beets.util.confit import ConfigSource, load_yaml
+from confuse import ConfigSource, load_yaml
 from beetsplug.xtractor.command import XtractorCommand
 
 

--- a/beetsplug/xtractor/command.py
+++ b/beetsplug/xtractor/command.py
@@ -14,7 +14,7 @@ import yaml
 from beets import dbcore
 from beets.library import Library, Item, parse_query_string
 from beets.ui import Subcommand, decargs
-from beets.util.confit import Subview
+from confuse import Subview
 from beetsplug.xtractor import helper
 
 

--- a/beetsplug/xtractor/helper.py
+++ b/beetsplug/xtractor/helper.py
@@ -6,7 +6,7 @@ import json
 import logging
 import os
 
-from beets.util.confit import Subview
+from confuse import Subview
 
 # Get values as: plg_ns['__PLUGIN_NAME__']
 plg_ns = {}

--- a/test/helper.py
+++ b/test/helper.py
@@ -22,7 +22,7 @@ from beets.util import (
     bytestring_path,
     displayable_path,
 )
-from beets.util.confit import Subview, Dumper
+from confuse import Subview, Dumper
 from beetsplug import xtractor
 from beetsplug.xtractor import helper
 from six import StringIO


### PR DESCRIPTION
`beets.utils.confit` is deprecated and should be replaced by `confuse`.