### PR TITLE
Fix error when output filename is an url

### DIFF
--- a/beetsplug/xtractor/command.py
+++ b/beetsplug/xtractor/command.py
@@ -262,7 +262,7 @@ class XtractorCommand(Subcommand):
 
     def _get_output_path_for_item(self, item: Item):
         identifier = item.get("mb_trackid")
-        if not identifier:
+        if not identifier or '/' in identifier:
             input_path = self._get_input_path_for_item(item)
             identifier = hashlib.md5(input_path.encode('utf-8')).hexdigest()
 


### PR DESCRIPTION
- Fixes #16
- mb_trackid contains an URL populated by some metadata source plugins (eg.
  bandcamp)
- use the md5 filename generation lines (that were already there for cases
  where mb_trackid is not present at all) in case mb_trackid contains a slash
  (/) character
- could be advanced later if other unwanted characters populated by source
  plugins are found in mb_trackid but should be a good enough for now fix.