### PR TITLE
Support auto-detection of threads / Note on tilde expansion in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,12 @@ xtractor:
 First of all, you will need adjust all paths. Put the path of the extractor binary in `essentia_extractor` and
 substitute the location of the SVM models with your local path under the `svm_models` section. Finally, set
 the `output_path` to indicate where the extracted data files will be stored. If you do not set this, a temporary path
-will be used.
+will be used. 
+
+**Note on shell tilde expansion**:  Please note that you cannot use shell expansion on the `svm_models` (i.e.: do not use `~` for your home folder).
+The entire section of `extractor_profile` is passed as-is to the essentia extractor binary and it will not do tilde expansion on your paths.
+The rest of the path keys such as `essentia_extractor` and `output_path` are used by the plugin itself and it will take
+care of expanding the tilde symbol (`~`) to the home directory of the user running the script. 
 
 By default both `keep_output` and `keep_profile` options are set to `no`. This means that after extraction (and the
 storage of the important information) the profile files used to pass to the extractors, and the json files created by

--- a/README.md
+++ b/README.md
@@ -92,13 +92,16 @@ by `mb_trackid`) - speeding up the process a lot.
 
 The `force` option instructs the plugin to execute on items which already have the required properties.
 
-The `threads` option sets the number of concurrent executions. If you remove this option the number of cores present on your machine will be used. The extraction is quite a CPU intensive process so there might be cases when you want to limit it to just 1.
+The `threads` option sets the number of concurrent executions. By default this is set to 1.
+If you remove this option or if you set it to 0 the number of CPU cores present on your machine will be used.
+The extraction is quite a CPU intensive process so there might be cases when you want to limit it to just 1.
 
 The `write` option instructs the plugin to write the extracted attributes to the media file right away. Note that only `bpm` is actually written to the media file, all the other attributes are flex attributes and are only stored in the database.
 
 The `dry-run` option shows what would be done without actually doing it.
 
 **NOTE**: Please note that the `auto` option is not yet implemented. For now you will have to call the xtractor plugin manually.
+
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -80,12 +80,12 @@ xtractor:
 First of all, you will need adjust all paths. Put the path of the extractor binary in `essentia_extractor` and
 substitute the location of the SVM models with your local path under the `svm_models` section. Finally, set
 the `output_path` to indicate where the extracted data files will be stored. If you do not set this, a temporary path
-will be used. 
+will be used.
 
 **Note on shell tilde expansion**:  Please note that you cannot use shell expansion on the `svm_models` (i.e.: do not use `~` for your home folder).
 The entire section of `extractor_profile` is passed as-is to the essentia extractor binary and it will not do tilde expansion on your paths.
 The rest of the path keys such as `essentia_extractor` and `output_path` are used by the plugin itself and it will take
-care of expanding the tilde symbol (`~`) to the home directory of the user running the script. 
+care of expanding the tilde symbol (`~`) to the home directory of the user running the script.
 
 By default both `keep_output` and `keep_profile` options are set to `no`. This means that after extraction (and the
 storage of the important information) the profile files used to pass to the extractors, and the json files created by

--- a/beetsplug/xtractor/command.py
+++ b/beetsplug/xtractor/command.py
@@ -5,6 +5,7 @@
 import hashlib
 import json
 import os
+import multiprocessing
 import tempfile
 from concurrent import futures
 from optparse import OptionParser
@@ -117,6 +118,11 @@ class XtractorCommand(Subcommand):
         self.cfg_version = options.version
         self.cfg_count_only = options.count_only
         self.cfg_quiet = options.quiet
+
+        # Auto Thread Count
+        if self.cfg_threads == 0:
+            self.cfg_threads = multiprocessing.cpu_count()
+            self._say("Adjusting max threads to CPU count: {0}".format(self.cfg_threads), True)
 
         self.lib = lib
         self.query = decargs(arguments)


### PR DESCRIPTION
I found these two changes hanging around in devel branch. I tested it on my own (Linux) machine, threads count is detected fine. I reviewed the usage of self.cfg_threads further on in the code, and think it's used correctly (since obviously is the same variable as the default of 1 threads uses). You might have reasons why you didn't merge it into master yet or it was just a lack of time issue and it got forgotten? Thanks for a quick review.

Also I reviewed the valuable addition to the README describing that tilde expansion should be avoided. I also came across an issue where it was reported/discussed and I think this change is perfectly fine and should go into master as soon as possible.