### PR TITLE
Log the command line being executed on extraction

### DIFF
--- a/beetsplug/xtractor/command.py
+++ b/beetsplug/xtractor/command.py
@@ -240,8 +240,9 @@ class XtractorCommand(Subcommand):
         self._say("Output: {0}".format(output_path))
         self._say("Profile: {0}".format(profile_path))
 
-        proc = Popen([extractor_path, input_path, output_path, profile_path],
-                     stdout=PIPE, stderr=PIPE)
+        cmd_and_args = [extractor_path, input_path, output_path, profile_path]
+        self._say("Executing: {0}".format(' '.join(f'"{a}"' for a in cmd_and_args)))
+        proc = Popen(cmd_and_args, stdout=PIPE, stderr=PIPE)
         stdout, stderr = proc.communicate()
 
         self._say("The process exited with code: {0}".format(proc.returncode))


### PR DESCRIPTION
Even though all necessary components to construct a full extractor command are
being logged in info level already, this tiny change further eases debugging.

A line starting with "Executing:" is added to the log:

```
xtractor: Number of items to be processed: 1
xtractor: Running analysis for: /home/jojo/Music/Ed Chamberlain/Mixxy EP 1/03 Dave (Vent remix).flac
xtractor: Extractor: /home/jojo/software/essentia/essentia-extractors-v2.1_beta2_acousticbrainz/streaming_extractor_music
xtractor: Input: /home/jojo/Music/Ed Chamberlain/Mixxy EP 1/03 Dave (Vent remix).flac
xtractor: Output: /tmp/89609df6-ac1c-4265-a2f3-28761ae9d8ec.json
xtractor: Profile: /tmp/profile.yml
xtractor: Executing: "/home/jojo/software/essentia/essentia-extractors-v2.1_beta2_acousticbrainz/streaming_extractor_music" "/home/jojo/Music/Ed Chamberlain/Mixxy EP 1/03 Dave (Vent remix).flac" "/tmp/89609df6-ac1c-4265-a2f3-28761ae9d8ec.json" "/tmp/profile.yml"
```