### PR TITLE
Enable writing bpm to file tag

### DIFF
--- a/beetsplug/xtractor/command.py
+++ b/beetsplug/xtractor/command.py
@@ -173,7 +173,7 @@ class XtractorCommand(Subcommand):
 
     def run_full_analysis(self, item):
         self._run_analysis(item)
-        # self._run_write_to_item(item)
+        self._run_write_to_item(item)
 
         # Delete output files (if config wants)
         if self.config["keep_output"].exists() and not self.config["keep_output"].get():


### PR DESCRIPTION
- Fixes #17
- The writing to the (standard) media file tag "bpm" was prepared in code
  already.
- Above mentioned issue verifies that it is working. The user uses it in their
  own foss project (musicplayerplus) where they patched the change into the
  latest release.
- My own tests verify the correct writing to the file tag as well.
- We don't need to worry about adding additional media tag fields, (as is
  prepared in beets-xtractor's code already), since bpm is a standard media
  file tag and will be present in beets already.
- This feature is already mentioned as "working" in the README.