### PR TITLE
fix xtractor path handling for newer beets

### DIFF
--- a/beetsplug/xtractor/command.py
+++ b/beetsplug/xtractor/command.py
@@ -16,6 +16,7 @@ import yaml
 from beets import dbcore
 from beets.library import Library, Item, parse_query_string
 from beets.ui import Subcommand, decargs
+from beets.util import bytestring_path, normpath, syspath
 from beetsplug.xtractor import helper
 from confuse import Subview
 
@@ -288,7 +289,18 @@ class XtractorCommand(Subcommand):
         return os.path.join(self._get_extraction_output_path(), output_file)
 
     def _get_input_path_for_item(self, item: Item):
-        input_path = item.get("path").decode("utf-8")
+        input_path = item.get("path")
+        if isinstance(input_path, str):
+            input_path = bytestring_path(input_path)
+
+        if not os.path.isabs(os.fsdecode(input_path)):
+            library_directory = self.lib.directory
+            if isinstance(library_directory, str):
+                library_directory = bytestring_path(library_directory)
+            input_path = os.path.join(library_directory, input_path)
+
+        input_path = normpath(input_path)
+        input_path = syspath(input_path)
 
         if not os.path.isfile(input_path):
             raise FileNotFoundError("Input file({}) not found!".format(input_path))

--- a/test/00_completion_test.py
+++ b/test/00_completion_test.py
@@ -4,7 +4,13 @@
 #  Created: 3/12/20, 11:42 PM
 #  License: See LICENSE.txt
 
+import os
+
+from beets.library import Item
+from beets.util import displayable_path
+
 from beetsplug.xtractor import about
+from beetsplug.xtractor.command import XtractorCommand
 
 from test.helper import TestHelper, Assertions, \
     PLUGIN_NAME, PLUGIN_SHORT_DESCRIPTION, \
@@ -12,6 +18,10 @@ from test.helper import TestHelper, Assertions, \
     capture_log
 
 plg_log_ns = 'beets.{}'.format(PLUGIN_NAME)
+
+
+def _normalize_test_path(path):
+    return os.path.normpath(displayable_path(path).removeprefix('\\\\?\\'))
 
 
 class CompletionTest(TestHelper, Assertions):
@@ -57,3 +67,27 @@ class CompletionTest(TestHelper, Assertions):
             ver=PLUGIN_VERSION
         )
         self.assertIn(versioninfo, "\n".join(logs))
+
+    def test_get_input_path_for_item_with_absolute_path(self):
+        path = self.lib_path(b"absolute.flac")
+        with open(path, "wb"):
+            pass
+
+        item = Item(path=path)
+        cmd = XtractorCommand(self.config[PLUGIN_NAME])
+        cmd.lib = self.lib
+
+        self.assertEqual(os.path.normpath(path.decode()), _normalize_test_path(cmd._get_input_path_for_item(item)))
+
+    def test_get_input_path_for_item_with_relative_path(self):
+        relative_path = b"nested/relative.flac"
+        absolute_path = self.lib_path(relative_path)
+        os.makedirs(os.path.dirname(absolute_path), exist_ok=True)
+        with open(absolute_path, "wb"):
+            pass
+
+        item = Item(path=relative_path)
+        cmd = XtractorCommand(self.config[PLUGIN_NAME])
+        cmd.lib = self.lib
+
+        self.assertEqual(os.path.normpath(absolute_path.decode()), _normalize_test_path(cmd._get_input_path_for_item(item)))

--- a/test/helper.py
+++ b/test/helper.py
@@ -127,7 +127,6 @@ class TestHelper(TestCase, Assertions):
 
     def reset_beets(self, config_file: bytes):
         self.teardown_beets()
-        plugins._classes = {xtractor.XtractorPlugin}
         self._setup_beets(config_file)
 
     def _setup_beets(self, config_file: bytes):
@@ -142,7 +141,7 @@ class TestHelper(TestCase, Assertions):
         shutil.copyfile(config_file, self.config.user_config_path())
         self.config.read()
 
-        self.config['plugins'] = []
+        self.config['plugins'] = [PLUGIN_NAME]
         self.config['verbose'] = True
         self.config['ui']['color'] = False
         self.config['threaded'] = False
@@ -157,7 +156,7 @@ class TestHelper(TestCase, Assertions):
         self.lib = beets.library.Library(':memory:', self.libdir)
 
         # This will initialize (create instance) of the plugins
-        plugins.find_plugins()
+        plugins.load_plugins()
 
     def teardown_beets(self):
         self.unload_plugins()
@@ -191,16 +190,15 @@ class TestHelper(TestCase, Assertions):
 
     @staticmethod
     def unload_plugins():
-        for plugin in plugins._classes:
+        for plugin in plugins._instances:
             plugin.listeners = None
-            plugins._classes = set()
-            plugins._instances = {}
+        plugins._instances = []
 
     def runcli(self, *args):
         # TODO mock stdin
         with capture_stdout() as out:
             try:
-                ui._raw_main(_convert_args(list(args)), self.lib)
+                ui._raw_main(_convert_args(list(args)))
             except ui.UserError as u:
                 # TODO remove this and handle exceptions in tests
                 print(u.args[0])


### PR DESCRIPTION
Fixes #39 

Fix `xtractor` path resolution for newer beets releases by resolving library-relative item paths against the configured music directory before checking file existence. Also, update the test harness and add coverage for both absolute and relative stored paths so the plugin stays compatible with the current beets.

Tested it locally as well, and everything works after the fix. 